### PR TITLE
Add J2EE DataSource Bridge and Configuration classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,24 @@
       <artifactId>dropwizard-core</artifactId>
       <version>${dropwizard.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-db</artifactId>
+      <version>${dropwizard.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-hibernate</artifactId>
+      <version>${dropwizard.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-migrations</artifactId>
+      <version>${dropwizard.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/datasource/J2EEDataSourceFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/datasource/J2EEDataSourceFactory.java
@@ -1,0 +1,56 @@
+package be.fluid_it.tools.dropwizard.box.bridge.datasource;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.DatabaseConfiguration;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.hibernate.HibernateBundle;
+import io.dropwizard.migrations.MigrationsBundle;
+
+import java.util.Map;
+
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+import be.fluid_it.tools.dropwizard.box.config.J2EEDataSourceConfiguration;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A {@link DataSourceFactory} that provides {@link DataSource} configured in
+ * J2EE Container.<br />
+ * <br />
+ * 
+ * You should override
+ * {@link DatabaseConfiguration#getDataSourceFactory(io.dropwizard.Configuration)}
+ * from your database bundle to return this factory, using a
+ * {@link J2EEDataSourceConfiguration} defined in your application
+ * {@link Configuration}.
+ * 
+ * @see HibernateBundle#getDataSourceFactory(io.dropwizard.Configuration)
+ * @see MigrationsBundle#getDataSourceFactory(io.dropwizard.Configuration)
+ */
+public class J2EEDataSourceFactory extends DataSourceFactory {
+    private J2EEDataSourceConfiguration configuration;
+
+    public J2EEDataSourceFactory(J2EEDataSourceConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    @JsonProperty
+    public Map<String, String> getProperties() {
+        return configuration.getProperties();
+    }
+
+    @Override
+    public ManagedDataSource build(MetricRegistry metricRegistry, String name) {
+        try {
+            return new J2EEManagedDataSource(this.configuration.getName());
+        } catch (NamingException e) {
+            throw new IllegalStateException("An error has occured while opening datasource " + name, e);
+        }
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/datasource/J2EEManagedDataSource.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/datasource/J2EEManagedDataSource.java
@@ -1,0 +1,86 @@
+package be.fluid_it.tools.dropwizard.box.bridge.datasource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+import io.dropwizard.db.ManagedDataSource;
+
+/**
+ * A {@link DataSource} configured in J2EE Container available through JNDI
+ * under java:comp/env context.
+ */
+public class J2EEManagedDataSource implements ManagedDataSource {
+    private DataSource j2eeDatasource;
+
+    public J2EEManagedDataSource(String dataSourceName) throws NamingException {
+        InitialContext ic = new InitialContext();
+        Context envCtx = (Context) ic.lookup("java:comp/env");
+        j2eeDatasource = (DataSource) envCtx.lookup(dataSourceName);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return j2eeDatasource.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return j2eeDatasource.getConnection(username, password);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return j2eeDatasource.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        j2eeDatasource.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        j2eeDatasource.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return j2eeDatasource.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return j2eeDatasource.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return j2eeDatasource.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return j2eeDatasource.isWrapperFor(iface);
+    }
+
+    @Override
+    public void start() throws Exception {
+    }
+
+    @Override
+    public void stop() throws Exception {
+        // We can't close DataSource here.
+        // Any good container should support closing Resource objects when not
+        // required
+        // In Tomcat define closeMethod="close" in Resource configuration
+    }
+
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/J2EEDataSourceConfiguration.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/J2EEDataSourceConfiguration.java
@@ -1,0 +1,42 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Maps;
+
+/**
+ * Embed this configuration into your dropwizard {@link Configuration} to use a
+ * {@link DataSource} configured in your J2EE Container.
+ */
+public class J2EEDataSourceConfiguration {
+    @NotNull
+    private String name;
+
+    @NotNull
+    private Map<String, String> properties = Maps.newLinkedHashMap();
+
+    /**
+     * @return Properties of the DataSourceFactory (like
+     *         {@link DataSourceFactory#getProperties()})
+     */
+    @JsonProperty
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    /**
+     * @return JNDI Name of the DataSource configured in J2EE Container.
+     */
+    @JsonProperty
+    public String getName() {
+        return name;
+    }
+
+}


### PR DESCRIPTION
This add bridge capabilities from DataSource configured in J2EE Context to Dropwizard DataSource.

This could be enhanced with more documentation and maybe a sample project and some sanity check tests, but it already contains JavaDoc that makes the feature usable.

Related to #3
