### PR TITLE
Add JndiConfigurationBridge support

### DIFF
--- a/src/main/java/be/fluid_it/tools/dropwizard/box/WebApplication.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/WebApplication.java
@@ -1,6 +1,9 @@
 package be.fluid_it.tools.dropwizard.box;
 
+import be.fluid_it.tools.dropwizard.box.config.BridgedConfigurationFactoryFactory;
 import be.fluid_it.tools.dropwizard.box.config.ClasspathConfigurationSourceProvider;
+import be.fluid_it.tools.dropwizard.box.config.ConfigurationBridge;
+import be.fluid_it.tools.dropwizard.box.config.JndiConfigurationBridge;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
@@ -23,6 +26,7 @@ public abstract class WebApplication<C extends Configuration> extends Applicatio
     private final Application<C> dropwizardApplication;
     private final String[] args;
     private Environment dropwizardEnvironment;
+    private ConfigurationBridge configurationBridge;
 
     public static ServletContext servletContext() {
         return theServletContext;
@@ -37,8 +41,19 @@ public abstract class WebApplication<C extends Configuration> extends Applicatio
         this.args = args;
     }
 
+    public void setConfigurationBridge(ConfigurationBridge configurationBridge) {
+        this.configurationBridge = configurationBridge;
+    }
+
+    public ConfigurationBridge getConfigurationBridge() {
+        return configurationBridge;
+    }
+
     @Override
     public void initialize(Bootstrap<C> bootstrap) {
+        if (configurationBridge != null) {
+            bootstrap.setConfigurationFactoryFactory(new BridgedConfigurationFactoryFactory<C>(configurationBridge));
+        }
         // Swaps the default FileConfigurationSourceProvider
         bootstrap.setConfigurationSourceProvider(new ClasspathConfigurationSourceProvider());
         dropwizardApplication.initialize(bootstrap);

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/BridgedConfigurationFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/BridgedConfigurationFactory.java
@@ -1,0 +1,41 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+
+import javax.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+
+public class BridgedConfigurationFactory<T extends Configuration> extends ConfigurationFactory<T> {
+    private ConfigurationBridge<T> configurationBridge;
+
+    public BridgedConfigurationFactory(ConfigurationBridge bridge, Class<T> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix) {
+        super(klass, validator, objectMapper, propertyPrefix);
+        configurationBridge = bridge;
+    }
+
+    @Override
+    public T build(File file) throws IOException, ConfigurationException {
+        T configuration = super.build(file);
+        configurationBridge.load(configuration);
+        return configuration;
+    }
+
+    @Override
+    public T build(ConfigurationSourceProvider provider, String path) throws IOException, ConfigurationException {
+        T configuration = super.build(provider, path);
+        configurationBridge.load(configuration);
+        return configuration;
+    }
+
+    @Override
+    public T build() throws IOException, ConfigurationException {
+        T configuration = super.build();
+        configurationBridge.load(configuration);
+        return configuration;
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/BridgedConfigurationFactoryFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/BridgedConfigurationFactoryFactory.java
@@ -1,0 +1,21 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationFactoryFactory;
+
+import javax.validation.Validator;
+
+public class BridgedConfigurationFactoryFactory<T extends Configuration> implements ConfigurationFactoryFactory<T> {
+    private final ConfigurationBridge configurationBridge;
+
+    public BridgedConfigurationFactoryFactory(ConfigurationBridge configurationBridge) {
+        this.configurationBridge = configurationBridge;
+    }
+
+    @Override
+    public ConfigurationFactory<T> create(Class<T> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix) {
+        return new BridgedConfigurationFactory<T>(configurationBridge, klass, validator, objectMapper, propertyPrefix);
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationBridge.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationBridge.java
@@ -1,0 +1,7 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import io.dropwizard.Configuration;
+
+public interface ConfigurationBridge<C extends Configuration> {
+    void load(C configuration);
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriter.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriter.java
@@ -1,0 +1,5 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+public interface ConfigurationWriter {
+    void write(String[] path, Object value) throws ConfigurationWriterException;
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriterException.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriterException.java
@@ -1,0 +1,22 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+public class ConfigurationWriterException extends Exception {
+    public ConfigurationWriterException() {
+    }
+
+    public ConfigurationWriterException(String message) {
+        super(message);
+    }
+
+    public ConfigurationWriterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConfigurationWriterException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConfigurationWriterException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriterFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ConfigurationWriterFactory.java
@@ -1,0 +1,7 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import io.dropwizard.Configuration;
+
+public interface ConfigurationWriterFactory<C extends Configuration> {
+    ConfigurationWriter build(C configuration);
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/JndiConfigurationBridge.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/JndiConfigurationBridge.java
@@ -1,0 +1,81 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import io.dropwizard.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.naming.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JndiConfigurationBridge<C extends Configuration> implements ConfigurationBridge<C> {
+    private Logger log = LoggerFactory.getLogger(JndiConfigurationBridge.class);
+
+    private final ConfigurationWriterFactory writerFactory;
+    private final String configurationContext;
+
+    private static final String DEFAULT_CONTEXT = "java:comp/env/dropwizard/configuration";
+
+    public JndiConfigurationBridge() {
+        this(DEFAULT_CONTEXT);
+    }
+
+    public JndiConfigurationBridge(String configurationContext) {
+        this(new ReflectionConfigurationWriterFactory(), configurationContext);
+    }
+
+    public JndiConfigurationBridge(ConfigurationWriterFactory writerFactory) {
+        this(writerFactory, DEFAULT_CONTEXT);
+    }
+
+    public JndiConfigurationBridge(ConfigurationWriterFactory writerFactory, String configurationContext) {
+        this.configurationContext = configurationContext;
+        this.writerFactory = writerFactory;
+    }
+
+    public void load(C configuration) {
+        ConfigurationWriter configurationWriter = writerFactory.build(configuration);
+
+        try {
+            Context initCtx = new InitialContext();
+            Context envCtx = (Context) initCtx.lookup(configurationContext);
+            writeEnumeration(envCtx, configurationWriter, null);
+
+        } catch (NamingException e) {
+            log.error("Can't configure property from J2EE Context", e);
+        }
+
+    }
+
+    private void writeEnumeration(Context parentContext, ConfigurationWriter configurationWriter, List<String> path) {
+        try {
+            NamingEnumeration<NameClassPair> list = parentContext.list("");
+            while (list.hasMore()) {
+                NameClassPair next = list.next();
+                String name = next.getName();
+                if (path == null) {
+                    path = new ArrayList<>();
+                }
+                path.add(name);
+                try {
+                    Object value = parentContext.lookup(name);
+                    if (value instanceof Context) {
+                        writeEnumeration((Context) value, configurationWriter, path);
+                    } else {
+                        configurationWriter.write(path.toArray(new String[path.size()]), value);
+                    }
+                } catch (NamingException e) {
+                    log.error("Can't read property " + name + " from JNDI Naming Context " + configurationContext, e);
+                } catch (ConfigurationWriterException e) {
+                    log.error("Can't write property " + name + " to Dropwizard Configuration", e);
+                }
+                path.remove(path.size() - 1);
+
+            }
+        } catch (NamingException e) {
+            log.error("Can't configure property from J2EE Context", e);
+        }
+
+
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ReflectionConfigurationWriter.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ReflectionConfigurationWriter.java
@@ -1,0 +1,69 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ReflectionConfigurationWriter implements ConfigurationWriter {
+    private Object configuration;
+
+    public ReflectionConfigurationWriter(Object configuration) {
+        this.configuration = configuration;
+    }
+
+    public void setConfiguration(Object configuration) {
+        this.configuration = configuration;
+    }
+
+    public void write(String[] path, Object inputValue) throws ConfigurationWriterException {
+        Object conf = this.configuration;
+        for (int i = 0; i < path.length; i++) {
+            if (i == path.length - 1) {
+                PropertyDescriptor propertyDescriptor;
+                try {
+                    propertyDescriptor = new PropertyDescriptor(path[i], conf.getClass());
+                } catch (Exception e) {
+                    throw new ConfigurationWriterException("Failed!", e);
+                }
+
+                Class<?> propertyType = propertyDescriptor.getPropertyType();
+                if (propertyType.isPrimitive()) {
+                    propertyType = ClassUtils.primitiveToWrapper(propertyType);
+                }
+                Object value = inputValue;
+                if (inputValue instanceof String && propertyType != String.class) {
+                    try {
+                        Method valueOfMethod = propertyType.getMethod("valueOf", String.class);
+                        value = valueOfMethod.invoke(null, inputValue);
+                    } catch (NoSuchMethodException e) {
+                        value = inputValue;
+                    } catch (Exception e) {
+                        throw new ConfigurationWriterException("Failed!", e);
+                    }
+                }
+
+                try {
+                    propertyDescriptor.getWriteMethod().invoke(conf, value);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new ConfigurationWriterException("Failed!", e);
+                }
+
+            } else {
+                Method getterMethod;
+                try {
+                    getterMethod = conf.getClass().getMethod("get" + StringUtils.capitalize(path[i]));
+                } catch (Exception e) {
+                    throw new ConfigurationWriterException("Failed", e);
+                }
+                try {
+                    conf = getterMethod.invoke(conf);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new ConfigurationWriterException("Failed", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/config/ReflectionConfigurationWriterFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/config/ReflectionConfigurationWriterFactory.java
@@ -1,0 +1,10 @@
+package be.fluid_it.tools.dropwizard.box.config;
+
+import io.dropwizard.Configuration;
+
+public class ReflectionConfigurationWriterFactory<C extends Configuration> implements ConfigurationWriterFactory<C> {
+    @Override
+    public ConfigurationWriter build(C configuration) {
+        return new ReflectionConfigurationWriter(configuration);
+    }
+}


### PR DESCRIPTION
This adds a bridge between JEE JNDI Context add Dropwizard configuration, providing a way to configure the Dropwizard application through standard JEE Context.

Default ConfigurationWriter is ReflectionConfigurationWriter and use java.beans.PropertyDescriptor to define object property values, so dropwizard Configuration class must declare proper JavaBeans getter and setter methods defined for this to work properly (This could maybe be enhanced with more handmade reflection to work event if those get/set methods doesn't exists).

**Application wrapper declares the bridge**

``` java
@WebListener
public class WebApplicationWar extends WebApplication<MyConfiguration> {
    public WebApplicationWar() {
        super(new MyApplication(), "myapp.yml");
        setConfigurationBridge(new JndiConfigurationBridge()); // Define the JndiConfigurationBridge. Other constructors allow customization of this bridge.
    }
}
```

**Configuration file is still there, and serves as default configuration**

``` yml
server:
  type: bridge
  applicationContextPath: /api/v1
  adminContextPath: /admin

service:
  ext:
    read: false
    write: false
    uri: http://some-webservice
```

**Tomcat context can override those default values**

``` xml
<?xml version='1.0' encoding='utf-8'?>
<Context>
    ....
    <Environment name="dropwizard/configuration/service/ext/read" type="java.lang.Boolean" value="true"/>
    <Environment name="dropwizard/configuration/service/ext/write" type="java.lang.Boolean" value="true"/>
    <Environment name="dropwizard/configuration/service/ext/uri" type="java.lang.String" value="http://webservice-mirror"/>

</Context>

```

So the effective configuration is now ...

``` yml
server:
  type: bridge
  applicationContextPath: /api/v1
  adminContextPath: /admin

service:
  ext:
    read: true
    write: true
    uri: http://webservice-mirror
```
