### PR TITLE
Initialize Dummy Jersey properly for lifecycle support

### DIFF
--- a/src/main/java/be/fluid_it/tools/dropwizard/box/WebApplication.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/WebApplication.java
@@ -9,6 +9,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.LifeCycle;
 
 import javax.servlet.ServletContext;
@@ -87,18 +88,13 @@ public abstract class WebApplication<C extends Configuration> extends Applicatio
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        if (dropwizardEnvironment != null) {
-          LifecycleEnvironment lifecycle = dropwizardEnvironment.lifecycle();
-          if (lifecycle != null) {
-            for (LifeCycle managed : lifecycle.getManagedObjects()) {
-              try {
-                managed.stop();
-              } catch (Exception e) {
+        Server server = (Server)theServletContext.getAttribute("fakeJettyServer");
+        if (server != null) {
+            try {
+                server.stop();
+            } catch (Exception e) {
                 throw new RuntimeException("Shutdown of Dropwizard failed ...", e);
-              }
             }
-          }
-          dropwizardEnvironment = null;
         }
         theServletContext = null;
     }

--- a/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/JEEBridge.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/JEEBridge.java
@@ -1,9 +1,9 @@
 package be.fluid_it.tools.dropwizard.box.bridge;
 
 import be.fluid_it.tools.dropwizard.box.WebApplication;
-import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,21 +16,19 @@ import java.util.*;
 public class JEEBridge extends Server {
     private Logger logger = LoggerFactory.getLogger(JEEBridge.class);
 
-    private final Environment environment;
-
     private final List<Connector> connectors = new LinkedList<Connector>();
     private final Map<String, Object> attributesByName = new HashMap<String, Object>();
     private final List<Handler> handlers = new LinkedList<Handler>();
+
+    public JEEBridge(ThreadPool threadPool) {
+        super(threadPool);
+    }
 
     private enum ServerState {
         FAILED, STARTING, STARTED, STOPPING, STOPPED;
     }
 
     private ServerState serverState = ServerState.STARTED;
-
-    public JEEBridge(Environment environment) {
-        this.environment = environment;
-    }
 
     @Override
     public Connector[] getConnectors() {
@@ -189,13 +187,25 @@ public class JEEBridge extends Server {
     // Start
 
     @Override
+    public boolean isDumpAfterStart() {
+        return false;
+    }
+
+    @Override
+    public boolean isDumpBeforeStop() {
+        return false;
+    }
+
+    @Override
     protected void doStart() throws Exception {
-        logger.info("Dummy start Jetty server ...");
+        logger.info("Start Bridged Jetty server ...");
+        super.doStart();
     }
 
     @Override
     protected void doStop() throws Exception {
-        logger.info("Dummy stop Jetty server ...");
+        logger.info("Stop Bridged Jetty server ...");
+        super.doStop();
     }
 
 }


### PR DESCRIPTION
After more thinkings about the Jersey lifecycle, I think it's really acceptable to use this.

It brings back features developed in #7 that were not merged because of the _J2EE Unmanaged_ QueuedThreadPool problem (Using ThreadPool is J2EE environment is not recommanded).

It's seems to me acceptable to bring it back, because actual implementation use the default QueuedThreadPool initialized in jersey Server constructor. So even if the fake jetty server is not started (=current master), this ThreadPool is created and used by Jetty internals.

Also, this ensure that lifecycle is properly initialized and flows naturally in Jetty process, causing dropwizard managed objects to be properly stopped **and started**. Current implementation doesn't call `start()` on dropwizard managed objects.
