### PR TITLE
Changed JEEBridgeFactory parent class

### DIFF
--- a/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/JEEBridgeFactory.java
+++ b/src/main/java/be/fluid_it/tools/dropwizard/box/bridge/JEEBridgeFactory.java
@@ -1,8 +1,8 @@
 package be.fluid_it.tools.dropwizard.box.bridge;
 
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.server.AbstractServerFactory;
 import io.dropwizard.server.ServerFactory;
+import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.setup.Environment;
 
 import java.util.Enumeration;
@@ -23,7 +23,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletMapping;
 import org.eclipse.jetty.util.thread.ThreadPool;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,37 +33,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("bridge")
-public class JEEBridgeFactory extends AbstractServerFactory implements ServerFactory {
+public class JEEBridgeFactory extends SimpleServerFactory implements ServerFactory {
     private Logger logger = LoggerFactory.getLogger(JEEBridgeFactory.class);
-
-    @NotEmpty
-    private String applicationContextPath = "/application";
-
-    @NotEmpty
-    private String adminContextPath = "/admin";
 
     @NotNull
     private String[] servletsMappedFromRootContext = new String[] {};
-
-    @JsonProperty
-    public String getApplicationContextPath() {
-        return applicationContextPath;
-    }
-
-    @JsonProperty
-    public void setApplicationContextPath(String contextPath) {
-        this.applicationContextPath = contextPath;
-    }
-
-    @JsonProperty
-    public String getAdminContextPath() {
-        return adminContextPath;
-    }
-
-    @JsonProperty
-    public void setAdminContextPath(String contextPath) {
-        this.adminContextPath = contextPath;
-    }
 
     @JsonProperty
     public String[] getServletsMappedFromRootContext() {
@@ -99,13 +72,13 @@ public class JEEBridgeFactory extends AbstractServerFactory implements ServerFac
 
         WebApplication.servletContext().setAttribute("fakeJettyServer", server);
 
-        environment.getAdminContext().setContextPath(adminContextPath);
+        environment.getAdminContext().setContextPath(getAdminContextPath());
         final Handler adminHandler = createAdminServlet(server,
                 environment.getAdminContext(),
                 environment.metrics(),
                 environment.healthChecks());
-        registerOnJEEServletContext(adminContextPath, adminHandler);
-        environment.getApplicationContext().setContextPath(applicationContextPath);
+        registerOnJEEServletContext(getAdminContextPath(), adminHandler);
+        environment.getApplicationContext().setContextPath(getApplicationContextPath());
         final Handler applicationHandler = createAppServlet(server,
                 environment.jersey(),
                 environment.getObjectMapper(),
@@ -113,7 +86,7 @@ public class JEEBridgeFactory extends AbstractServerFactory implements ServerFac
                 environment.getApplicationContext(),
                 environment.getJerseyServletContainer(),
                 environment.metrics());
-        registerOnJEEServletContext(applicationContextPath, applicationHandler);
+        registerOnJEEServletContext(getApplicationContextPath(), applicationHandler);
         return server;
     }
 


### PR DESCRIPTION
- Changed JEEBridgeFactory parent class to SimpleServerFactory from
- AbstractServerFactory because of compatibility reasons with other
- libraries like com.smoketurner/dropwizard-swager that need the
- applicationContext
